### PR TITLE
Fixed and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 .vscode
 debug.log
 node_modules
-package-lock.json
-yarn.lock
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Hello there! As per rule: 

Yarn
> When you run either yarn or yarn add <package>, Yarn will generate a yarn.lock file within the root directory of your package. You don’t need to read or understand this file - just check it into source control. When other people start using Yarn instead of npm, the yarn.lock file will ensure that they get precisely the same dependencies as you have.

Npm
> package-lock.json is automatically generated for any operations where npm modifies either the node_modules tree, or package.json. It describes the exact tree that was generated, such that subsequent installs are able to generate identical trees, regardless of intermediate dependency updates.

> This file is intended to be committed into source repositories, and serves various purposes:

> Describe a single representation of a dependency tree such that teammates, deployments, and continuous integration are guaranteed to install exactly the same dependencies.

> Provide a facility for users to "time-travel" to previous states of node_modules without having to commit the directory itself.

> To facilitate greater visibility of tree changes through readable source control diffs.

> And optimize the installation process by allowing npm to skip repeated metadata resolutions for previously-installed packages.

> One key detail about package-lock.json is that it cannot be published, and it will be ignored if found in any place other than the toplevel package. It shares a format with npm-shrinkwrap.json(5), which is essentially the same file, but allows publication. This is not recommended unless deploying a CLI tool or otherwise using the publication process for producing production packages.

> If both package-lock.json and npm-shrinkwrap.json are present in the root of a package, package-lock.json will be completely ignored.

You have to keep **package-lock.json** and **yarn.lock** files in your project root folder.